### PR TITLE
Improve coloring

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -519,6 +519,7 @@ func toConsoleColor(rgb int) (c consoleColor) {
 		if b >= a {
 			c.blue = true
 		}
+		// non-intensed white is lighter than intensed black, so swap those.
 		if c.red && c.green && c.blue {
 			c.red, c.green, c.blue = false, false, false
 			c.intensity = true
@@ -538,6 +539,7 @@ func toConsoleColor(rgb int) (c consoleColor) {
 			c.blue = true
 		}
 		c.intensity = true
+		// intensed black is darker than non-intensed white, so swap those.
 		if !c.red && !c.green && !c.blue {
 			c.red, c.green, c.blue = true, true, true
 			c.intensity = false


### PR DESCRIPTION
256色について幾つか改良しました。
-   256色の減色アルゴリズムを改良
  -   先にintensityを考慮して、大きく2つのエリアに分割
  -   それぞれで基準点をR, G, Bのmin/maxの中間として決め、その基準点との大小関係で色を決定
  -   前景色、背景色、それぞれのattrをまとめて計算&計算結果をキャッシュ(高速化目的
-   背景色を操作する番号が間違っていたので修正 `39` → `48`
-   前景色、背景色、それぞれのリセット処理の追加 (`39` & `49`)

結果 beni の出力結果はこんな感じになります。
![sample](https://cloud.githubusercontent.com/assets/468368/4391651/1d6913bc-4407-11e4-8473-3fab50c5d829.png)
