### PR TITLE
gofmt on _example/main.go

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/mattn/go-colorable"
 	"github.com/Sirupsen/logrus"
+	"github.com/mattn/go-colorable"
 )
 
 func main() {


### PR DESCRIPTION
I am packaging this for Debian and realised this wasnt gofmt compliant.