### PR TITLE
デフォルトでカラーコードを吐いてくれなくなった。

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This package is possible to handle escape sequence for ansi color on windows.
 ## Usage
 
 ```go
+logrus.SetFormatter(&logrus.TextFormatter{ForceColors: true})
 logrus.SetOutput(colorable.NewColorableStdout())
 
 logrus.Info("succeeded")

--- a/_example/main.go
+++ b/_example/main.go
@@ -6,6 +6,7 @@ import (
 )
 
 func main() {
+	logrus.SetFormatter(&logrus.TextFormatter{ForceColors: true})
 	logrus.SetOutput(colorable.NewColorableStdout())
 
 	logrus.Info("succeeded")


### PR DESCRIPTION
日本語ですみません。最新のlogrusは以下のコミットが入ったため、デフォルトでカラーコードを吐いてくれなくなりました。よって、READMEやmain.goが思うように動きません。なので、このプルリクは動くようにするためのものです。よろしくお願い致します。

https://github.com/Sirupsen/logrus/commit/29d30d9f63041b476217e4ff8bfbbe788ee06c9e
