### PR TITLE
Return io.WriteCloser instead of io.Writer

### DIFF
--- a/colorable_others.go
+++ b/colorable_others.go
@@ -7,10 +7,10 @@ import (
 	"os"
 )
 
-func NewColorableStdout() io.Writer {
+func NewColorableStdout() io.WriteCloser {
 	return os.Stdout
 }
 
-func NewColorableStderr() io.Writer {
+func NewColorableStderr() io.WriteCloser {
 	return os.Stderr
 }

--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -59,13 +59,13 @@ var (
 )
 
 type Writer struct {
-	out     io.Writer
+	out     io.WriteCloser
 	handle  syscall.Handle
 	lastbuf bytes.Buffer
 	oldattr word
 }
 
-func NewColorableStdout() io.Writer {
+func NewColorableStdout() io.WriteCloser {
 	var csbi consoleScreenBufferInfo
 	out := os.Stdout
 	if !isatty.IsTerminal(out.Fd()) {
@@ -76,7 +76,7 @@ func NewColorableStdout() io.Writer {
 	return &Writer{out: out, handle: handle, oldattr: csbi.attributes}
 }
 
-func NewColorableStderr() io.Writer {
+func NewColorableStderr() io.WriteCloser {
 	var csbi consoleScreenBufferInfo
 	out := os.Stderr
 	if !isatty.IsTerminal(out.Fd()) {


### PR DESCRIPTION
Because os.Stdout is *os.File which supports Close method