### PR TITLE
Add a generic `NewColorable()` constructor

### DIFF
--- a/colorable_others.go
+++ b/colorable_others.go
@@ -7,6 +7,10 @@ import (
 	"os"
 )
 
+func NewColorable(file *os.File) io.Writer {
+	return file
+}
+
 func NewColorableStdout() io.Writer {
 	return os.Stdout
 }

--- a/colorable_others.go
+++ b/colorable_others.go
@@ -8,6 +8,10 @@ import (
 )
 
 func NewColorable(file *os.File) io.Writer {
+	if file == nil {
+		panic("nil passed instead of *os.File to NewColorable()")
+	}
+
 	return file
 }
 

--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -69,6 +69,10 @@ type Writer struct {
 }
 
 func NewColorable(file *os.File) io.Writer {
+	if file == nil {
+		panic("nil passed instead of *os.File to NewColorable()")
+	}
+
 	if isatty.IsTerminal(file.Fd()) {
 		var csbi consoleScreenBufferInfo
 		handle := syscall.Handle(file.Fd())

--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -68,26 +68,23 @@ type Writer struct {
 	oldattr word
 }
 
-func NewColorableStdout() io.Writer {
-	var csbi consoleScreenBufferInfo
-	out := os.Stdout
-	if !isatty.IsTerminal(out.Fd()) {
-		return out
+func NewColorable(file *os.File) io.Writer {
+	if isatty.IsTerminal(file.Fd()) {
+		var csbi consoleScreenBufferInfo
+		handle := syscall.Handle(file.Fd())
+		procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+		return &Writer{out: file, handle: handle, oldattr: csbi.attributes}
+	} else {
+		return file
 	}
-	handle := syscall.Handle(out.Fd())
-	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
-	return &Writer{out: out, handle: handle, oldattr: csbi.attributes}
+}
+
+func NewColorableStdout() io.Writer {
+	return NewColorable(os.Stdout)
 }
 
 func NewColorableStderr() io.Writer {
-	var csbi consoleScreenBufferInfo
-	out := os.Stderr
-	if !isatty.IsTerminal(out.Fd()) {
-		return out
-	}
-	handle := syscall.Handle(out.Fd())
-	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
-	return &Writer{out: out, handle: handle, oldattr: csbi.attributes}
+	return NewColorable(os.Stderr)
 }
 
 var color256 = map[int]int{


### PR DESCRIPTION
The generic constructor accepts any `os.File` pointer. This is useful when this library is used to support a generic colorable writer stream whose destination (stdout, stderr, log file, etc.) is determined dynamically at runtime.

Old constructors are kept for backwards compatibility.

Will conflict with #10