### PR TITLE
Make colorable encoding agnostic

### DIFF
--- a/colorable_test.go
+++ b/colorable_test.go
@@ -1,0 +1,30 @@
+package colorable
+
+import (
+	"bytes"
+	"testing"
+)
+
+// checkEncoding checks that colorable is output encoding agnostic as long as
+// the encoding is a superset of ASCII. This implies that one byte not part of
+// an ANSI sequence must give exactly one byte in output
+func checkEncoding(t *testing.T, data []byte) {
+	// Send non-UTF8 data to colorable
+	b := bytes.NewBuffer(make([]byte, 0, 10))
+	if b.Len() != 0 {
+		t.FailNow()
+	}
+	// TODO move colorable wrapping outside the test
+	c := NewNonColorable(b)
+	c.Write(data)
+	if b.Len() != len(data) {
+		t.Fatalf("%d bytes expected, got %d", len(data), b.Len())
+	}
+}
+
+func TestEncoding(t *testing.T) {
+	checkEncoding(t, []byte{})      // Empty
+	checkEncoding(t, []byte(`abc`)) // "abc"
+	checkEncoding(t, []byte(`é`))   // "é" in UTF-8
+	checkEncoding(t, []byte{233})   // 'é' in Latin-1
+}


### PR DESCRIPTION
ANSI sequences are defined in the ASCII encoding. Any stream of bytes in an encoding which is a superset of ASCII should be processable through a colorable and any byte that is not part of an ANSI sequence should kept as is.

go-colorable does not fit this because it uses `ReadRune`. This gives the following issues:
- a non-UTF-8 stream will be transformed into an UTF-8 stream with non-UTF8 bytes replaced by `U+FFFD`
- even an UTF-8 stream may be altered if the stream is fed through the colorable using `Write` calls that are not on rune boundaries

This patch adds tests checking encoding agnosticness, and shows that NonColorable fails as transmitting Latin-1. I can go further improving this testuite to include Colorable and provide fixes once this issue is recognized as a flaw that must be fixed.