### PR TITLE
Make buildable on Windows + goapp

### DIFF
--- a/colorable_appengine.go
+++ b/colorable_appengine.go
@@ -1,5 +1,4 @@
-// +build !windows
-// +build !appengine
+// +build appengine
 
 package colorable
 

--- a/colorable_others.go
+++ b/colorable_others.go
@@ -1,4 +1,4 @@
-// +build !windows OR appengine
+// +build !windows appengine
 
 package colorable
 

--- a/colorable_others.go
+++ b/colorable_others.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows OR appengine
 
 package colorable
 

--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package colorable
 
 import (

--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -1,3 +1,4 @@
+// +build windows
 // +build !appengine
 
 package colorable


### PR DESCRIPTION
[Echo](https://echo.labstack.com/), a web framework for go uses go-colorable
(To be exact, [gommon](https://github.com/labstack/gommon) depended by Echo uses go-colorable).

When developing an application for [Go on Google AppEngine](https://cloud.google.com/appengine/docs/go/) with Echo and testing it on Windows, it causes following build failure:
```
> goapp serve
...
2017/03/12 10:49:49 go-app-builder: Failed parsing input: parser: bad import "syscall" in github.com\mattn\go-colorable\colorable_others.go from GOPATH
```

This is caused as Go on Google AppEngine restricts importing syscall.

This change make go-colorable use `colorable_others.go` also on Windows when built with appengine.
