### PR TITLE
A patch to add SetConsoleTitle support to Windows for #21

### DIFF
--- a/_example/title/main.go
+++ b/_example/title/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	. "github.com/mattn/go-colorable"
+)
+
+func main() {
+	out := NewColorableStdout()
+	fmt.Fprint(out, "\x1B]0;TITLE Changed\007(See title and hit any key)")
+	var c [1]byte
+	os.Stdin.Read(c[:])
+}


### PR DESCRIPTION
This patch is to support #21 . I also want go-colorable to support SetConsoleTitle.
 If you find no problems, would you merge ?

I made a patch based on [How to change the title of an xterm: Dynamic titles](http://tldp.org/HOWTO/Xterm-Title-3.html)