### PR TITLE
Remove procGetConsoleScreenBufferInfo.Call whose result looks to be unused

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -405,8 +405,6 @@ func doTitleSequence(er *bytes.Reader) error {
 // Write write data on console
 func (w *Writer) Write(data []byte) (n int, err error) {
 	var csbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
-
 	er := bytes.NewReader(data)
 	var bw [1]byte
 loop:


### PR DESCRIPTION
On `func (w *Writer) Write([]byte)` of `colorable_windows.go`,  `procGetConsoleScreenBufferInfo` is called twice and the resuilt of the first one looks to be unused.

It does not cause any problems, but by removing one api-call, the speed to draw text may be improved.

<details>
(Japanese)<br>
Windows向けの Write 関数の中で２連続でprocGetConsoleScreenBufferInfoを呼び出している箇所があり、最初の方を削除してはどうかというプルリクエストです。実害はないのですが、自分のすごく重たい VM 上だと表示速度が目に見えて遅いので（go-colorable の責任ではなくハードが非力）、API呼び出しを減らして、少しでも表示速度を改善したいと思った次第です。
</details>