### PR TITLE
When the width of the screen is too large, garbage appears the screen after ESC[2J and some scrooling

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -599,13 +599,13 @@ loop:
 			switch n {
 			case 0:
 				cursor = coord{x: csbi.cursorPosition.x, y: csbi.cursorPosition.y}
-				count = dword(csbi.size.x - csbi.cursorPosition.x + (csbi.size.y-csbi.cursorPosition.y)*csbi.size.x)
+				count = dword(csbi.size.x) - dword(csbi.cursorPosition.x) + dword(csbi.size.y-csbi.cursorPosition.y)*dword(csbi.size.x)
 			case 1:
 				cursor = coord{x: csbi.window.left, y: csbi.window.top}
-				count = dword(csbi.size.x - csbi.cursorPosition.x + (csbi.window.top-csbi.cursorPosition.y)*csbi.size.x)
+				count = dword(csbi.size.x) - dword(csbi.cursorPosition.x) + dword(csbi.window.top-csbi.cursorPosition.y)*dword(csbi.size.x)
 			case 2:
 				cursor = coord{x: csbi.window.left, y: csbi.window.top}
-				count = dword(csbi.size.x - csbi.cursorPosition.x + (csbi.size.y-csbi.cursorPosition.y)*csbi.size.x)
+				count = dword(csbi.size.x) - dword(csbi.cursorPosition.x) + dword(csbi.size.y-csbi.cursorPosition.y)*dword(csbi.size.x)
 			}
 			procFillConsoleOutputCharacter.Call(uintptr(handle), uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 			procFillConsoleOutputAttribute.Call(uintptr(handle), uintptr(csbi.attributes), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))


### PR DESCRIPTION
When I set the buffer size for command prompt **300x300** and clear screen with

```
var Console = colorable.NewColorableStdout()
fmt.Fprint(Console, "\x1B[1;1H\x1B[2J")
```

Some garbage appears the screen after some scrooling.

![image](https://user-images.githubusercontent.com/3752189/34432852-7a859738-ecbe-11e7-86dc-0503349d1dce.png)

And I found the variable to count the cell to clean (`csbi.size.x` , `csbi.size.y`) is `short`-type and calculate as `short`-type. The overflow (>=32768) can occur.

If there are no problems ,  would you merge this patch ?