### PR TITLE
Fix: "<CSI>2K" does not erase characters at the bottom

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -625,10 +625,10 @@ loop:
 				cursor = coord{x: csbi.cursorPosition.x, y: csbi.cursorPosition.y}
 				count = dword(csbi.size.x - csbi.cursorPosition.x)
 			case 1:
-				cursor = coord{x: csbi.window.left, y: csbi.window.top + csbi.cursorPosition.y}
+				cursor = coord{x: csbi.window.left, y: csbi.cursorPosition.y}
 				count = dword(csbi.size.x - csbi.cursorPosition.x)
 			case 2:
-				cursor = coord{x: csbi.window.left, y: csbi.window.top + csbi.cursorPosition.y}
+				cursor = coord{x: csbi.window.left, y: csbi.cursorPosition.y}
 				count = dword(csbi.size.x)
 			}
 			procFillConsoleOutputCharacter.Call(uintptr(handle), uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))


### PR DESCRIPTION
## Before

![before](https://user-images.githubusercontent.com/48169/34948658-19422bbc-fa51-11e7-9bb4-16c92d7c146b.gif)

## After

![after](https://user-images.githubusercontent.com/48169/34948665-1f6dfa98-fa51-11e7-8d43-8915da124f07.gif)

## Description

`csbi.window.top` seems to become 1 or higher when scrolling down.
`csbi.window.top` seems the number of hidden lines at the top.
But `FillConsoleOutputCharacterW()`'s `dwWriteCoord` is a coordinate of terminal, not lines and cols.
NOTE: I could not test when `csbi.window.left` is 1 or higher.