### PR TITLE
Sequence `ESC [ <n> X`

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -645,18 +645,8 @@ loop:
 			}
 			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
 			var cursor coord
-			var count, written dword
+			var written dword
 			cursor = coord{x: csbi.cursorPosition.x, y: csbi.cursorPosition.y}
-			// switch n {
-			// case 0:
-			// 	count = dword(csbi.size.x - csbi.cursorPosition.x)
-			// case 1:
-			// 	cursor = coord{x: csbi.window.left, y: csbi.cursorPosition.y}
-			// 	count = dword(csbi.size.x - csbi.cursorPosition.x)
-			// case 2:
-			// 	cursor = coord{x: csbi.window.left, y: csbi.cursorPosition.y}
-			// 	count = dword(csbi.size.x)
-			// }
 			procFillConsoleOutputCharacter.Call(uintptr(handle), uintptr(' '), uintptr(n), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 			procFillConsoleOutputAttribute.Call(uintptr(handle), uintptr(csbi.attributes), uintptr(n), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
 		case 'm':

--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/mattn/go-isatty"
 )
 
 const (


### PR DESCRIPTION
Hi!
I've found that your package lacked `ESC [ <n> X` sequence documented [here](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#text-modification)
I haven't tested it, but it seems like `ansicon` [has](https://github.com/adoxa/ansicon/blob/37f92009f6ca4938a34a1d7cecff41d331c7423c/ANSI.c#L1587) this sequence 
So here it is )
Please check if everything done correctly cause I did it "blindfolded" :)
Thank you