### PR TITLE
refactoring colorable_test.go

### DIFF
--- a/colorable_test.go
+++ b/colorable_test.go
@@ -17,8 +17,7 @@ func checkEncoding(t *testing.T, data []byte) {
 		t.FailNow()
 	}
 	// TODO move colorable wrapping outside the test
-	c := NewNonColorable(b)
-	c.Write(data)
+	NewNonColorable(b).Write(data)
 	if b.Len() != len(data) {
 		t.Fatalf("%d bytes expected, got %d", len(data), b.Len())
 	}
@@ -66,8 +65,7 @@ func TestNonColorableNil(t *testing.T) {
 
 func TestNonColorableESC(t *testing.T) {
 	var b bytes.Buffer
-	c := NewNonColorable(&b)
-	c.Write([]byte{0x1b})
+	NewNonColorable(&b).Write([]byte{0x1b})
 	if b.Len() > 0 {
 		t.Fatalf("0 bytes expected, got %d", b.Len())
 	}
@@ -75,8 +73,7 @@ func TestNonColorableESC(t *testing.T) {
 
 func TestNonColorableBadESC(t *testing.T) {
 	var b bytes.Buffer
-	c := NewNonColorable(&b)
-	c.Write([]byte{0x1b, 0x1b})
+	NewNonColorable(&b).Write([]byte{0x1b, 0x1b})
 	if b.Len() > 0 {
 		t.Fatalf("0 bytes expected, got %d", b.Len())
 	}


### PR DESCRIPTION
Unify calling NonColorable.Write()