### PR TITLE
Support disable-bold,real-underline and native reverse-color.

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -27,6 +27,8 @@ const (
 	backgroundRed       = 0x40
 	backgroundIntensity = 0x80
 	backgroundMask      = (backgroundRed | backgroundBlue | backgroundGreen | backgroundIntensity)
+	commonLvbReverse    = 0x4000
+	commonLvbUnderscore = 0x8000
 
 	cENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4
 )
@@ -683,14 +685,18 @@ loop:
 					switch {
 					case n == 0 || n == 100:
 						attr = w.oldattr
-					case 1 <= n && n <= 5:
+					case n == 4:
+						attr |= commonLvbUnderscore
+					case (1 <= n && n <= 3) || n == 5:
 						attr |= foregroundIntensity
 					case n == 7:
-						attr = ((attr & foregroundMask) << 4) | ((attr & backgroundMask) >> 4)
-					case n == 22 || n == 25:
-						attr |= foregroundIntensity
+						attr |= commonLvbReverse
+					case n == 22:
+						attr &^= foregroundIntensity
+					case n == 24:
+						attr &^= commonLvbUnderscore
 					case n == 27:
-						attr = ((attr & foregroundMask) << 4) | ((attr & backgroundMask) >> 4)
+						attr &^= commonLvbReverse
 					case 30 <= n && n <= 37:
 						attr &= backgroundMask
 						if (n-30)&1 != 0 {


### PR DESCRIPTION
I tried to use `ESC[22m` to disable bold when ENABLE_VIRTUAL_TERMINAL_PROCESSING is **not** set, but it does not work as expected.

I made the [test-code](https://github.com/mattn/go-colorable/files/4573541/sample.go.txt) to compare before/after setting ENABLE_VIRTUAL_TERMINAL_PROCESSING.

The result is the picture below. `<%d>` means text decorated `ESC[%dm`

**(On the default browser view, it is not clear whether the bold is set or not, so please click image-area  TWICE to see clear-screenshot)**
![image](https://user-images.githubusercontent.com/3752189/80950003-0b74cd80-8e30-11ea-94cb-32aa5eeb5e8a.png)

I created the patch to reduce the differences.

- ESC[22m disables bold.
- ESC[27m never makes colors reversed. It disables reverse set by ESC[7m only.
- ESC[4m enables real-underline which is not bold.

The image below is the screenshot when sample.go runs on Windows8 VM. (Please ignore `After EnableColorsStdout`)

![image](https://user-images.githubusercontent.com/3752189/80949069-4118b700-8e2e-11ea-957a-63cffa77a76d.png)

Would you like to merge it if problem does not exist ?