### PR TITLE
Fix: on Windows 8.1, ESC[7m (REVERSE) does not work.

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -27,7 +27,6 @@ const (
 	backgroundRed       = 0x40
 	backgroundIntensity = 0x80
 	backgroundMask      = (backgroundRed | backgroundBlue | backgroundGreen | backgroundIntensity)
-	commonLvbReverse    = 0x4000
 	commonLvbUnderscore = 0x8000
 
 	cENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4
@@ -689,14 +688,15 @@ loop:
 						attr |= commonLvbUnderscore
 					case (1 <= n && n <= 3) || n == 5:
 						attr |= foregroundIntensity
-					case n == 7:
-						attr |= commonLvbReverse
+					case n == 7 || n == 27:
+						attr =
+							(attr &^ (foregroundMask | backgroundMask)) |
+								((attr & foregroundMask) << 4) |
+								((attr & backgroundMask) >> 4)
 					case n == 22:
 						attr &^= foregroundIntensity
 					case n == 24:
 						attr &^= commonLvbUnderscore
-					case n == 27:
-						attr &^= commonLvbReverse
 					case 30 <= n && n <= 37:
 						attr &= backgroundMask
 						if (n-30)&1 != 0 {


### PR DESCRIPTION
Sorry, **I mistaked** on #50 .  On Windows 8.1, the flag [COMMON_LVB_REVERSE_VIDEO](https://docs.microsoft.com/en-us/windows/console/char-info-str) is ignored by OS's default terminal.

Please look at the **rectangled area**. You will find `ESC[7m` does not work on Windows 8.1.

The current code on Windows 8.1 (This case has the problem that `ESC[7m` does not work.)
![image](https://user-images.githubusercontent.com/3752189/80967260-04aa8280-8e51-11ea-864f-9c6be1893663.png)

Same test on Windows 10, (This case has no problems.)
![image](https://user-images.githubusercontent.com/3752189/80967346-2efc4000-8e51-11ea-8abb-990048ad8be0.png)

So, I made the patch again which reverts the change for `ESC[7m` and `ESC[27m`.
But, it does not solute all problems. Please see these two images. `ESC[27m` loses the compatiblity with Windows10's native ANSI-Escape sequence.

Patch applied code on Windows8.1
![image](https://user-images.githubusercontent.com/3752189/80967741-d24d5500-8e51-11ea-8cb1-6851ead30487.png)

Patch applied code on Windows10.
![image](https://user-images.githubusercontent.com/3752189/80967571-8bf7f600-8e51-11ea-8dea-e429350b7751.png)

* When it is merged, `ESC[27m` loses the compatibility with Windows10's native sequence.
* When it is rejected, Windows 8.1 's ESC[7m does not work.

The idea exists to make the boolean-variable indicating `ESC[7m` is used or not, but I am afraid that it causes unexpected bugs.

I have added the undesired behavior to your code, so I have the duty to make the patch to revert it even if it may be rejected. I will respect your judgement whether the patch is merged or rejected. 