### PR TITLE
Write plain text in chunks

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -452,17 +452,21 @@ func (w *Writer) Write(data []byte) (n int, err error) {
 	} else {
 		er = bytes.NewReader(data)
 	}
-	var bw [1]byte
+	var plaintext bytes.Buffer
 loop:
 	for {
 		c1, err := er.ReadByte()
 		if err != nil {
+			plaintext.WriteTo(w.out)
 			break loop
 		}
 		if c1 != 0x1b {
-			bw[0] = c1
-			w.out.Write(bw[:])
+			plaintext.WriteByte(c1)
 			continue
+		}
+		_, err = plaintext.WriteTo(w.out)
+		if err != nil {
+			break loop
 		}
 		c2, err := er.ReadByte()
 		if err != nil {

--- a/noncolorable.go
+++ b/noncolorable.go
@@ -18,20 +18,21 @@ func NewNonColorable(w io.Writer) io.Writer {
 // Write writes data on console
 func (w *NonColorable) Write(data []byte) (n int, err error) {
 	er := bytes.NewReader(data)
-	var bw [1]byte
+	var plaintext bytes.Buffer
 loop:
 	for {
 		c1, err := er.ReadByte()
 		if err != nil {
+			plaintext.WriteTo(w.out)
 			break loop
 		}
 		if c1 != 0x1b {
-			bw[0] = c1
-			_, err = w.out.Write(bw[:])
-			if err != nil {
-				break loop
-			}
+			plaintext.WriteByte(c1)
 			continue
+		}
+		_, err = plaintext.WriteTo(w.out)
+		if err != nil {
+			break loop
 		}
 		c2, err := er.ReadByte()
 		if err != nil {


### PR DESCRIPTION
Instead of writing each byte alone to the console, always write the
full plain text up to the next escape sequence or until the write
is finished.
Doing so means more copying around of bytes, but improves write
performance significantly.

In a short test (writing 20000 lines to a console), time to write all lines went down by ~50%. 