### PR TITLE
Add //go:build lines

### DIFF
--- a/colorable_appengine.go
+++ b/colorable_appengine.go
@@ -1,3 +1,4 @@
+//go:build appengine
 // +build appengine
 
 package colorable

--- a/colorable_others.go
+++ b/colorable_others.go
@@ -1,5 +1,5 @@
-// +build !windows
-// +build !appengine
+//go:build !windows && !appengine
+// +build !windows,!appengine
 
 package colorable
 

--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -1,5 +1,5 @@
-// +build windows
-// +build !appengine
+//go:build windows && !appengine
+// +build windows,!appengine
 
 package colorable
 


### PR DESCRIPTION
Starting with Go 1.17, `//go:build` lines are preferred over `// +build`
lines, see https://golang.org/doc/go1.17#build-lines and
https://golang.org/design/draft-gobuild for details.

This change was generated by running Go 1.17 `go fmt ./...` which
automatically adds `//go:build` lines based on the existing `// +build`
lines.