### PR TITLE
Use correct field to specify Go version in GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-versions: ${{ matrix.go }}
+          go-version: ${{ matrix.go }}
       - uses: actions/checkout@v2
       - name: test
         shell: bash


### PR DESCRIPTION
There is a typo in the actions/setup-go step which leads to the Go
version not being picked up correctly. Fix it.