### PR TITLE
Create minimal interface to retain `Fd` under Windows.

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -87,9 +87,14 @@ var (
 	procCreateConsoleScreenBuffer  = kernel32.NewProc("CreateConsoleScreenBuffer")
 )
 
+type filewriter interface {
+	io.Writer
+	Fd() uintptr
+}
+
 // Writer provides colorable Writer to the console
 type Writer struct {
-	out       io.Writer
+	out       filewriter
 	handle    syscall.Handle
 	althandle syscall.Handle
 	oldattr   word
@@ -99,7 +104,7 @@ type Writer struct {
 }
 
 // NewColorable returns new instance of Writer which handles escape sequence from File.
-func NewColorable(file *os.File) io.Writer {
+func NewColorable(file filewriter) io.Writer {
 	if file == nil {
 		panic("nil passed instead of *os.File to NewColorable()")
 	}


### PR DESCRIPTION
Hello,

First of all, I'm new to Go, so maybe this isn't the best solution.

We needed to get `Colorable` working with [this interface](https://github.com/go-survey/survey/blob/master/terminal/stdio.go#L14). Just about everywhere else an `os.File` is returned, except on Windows where the passed-in value is wrapped.

I guess this could turn into a bit of a cat-and-mouse game with folks needing more and more methods from `os.File`, but I think this should get our type assertion working. Please let me know if there's a better/more idiomatic way to achieve this.

Thanks!