### PR TITLE
Allow to use io.Writer instead of *os.File for NewColorable func

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
           - macos-latest
           - windows-latest
         go:
+          - '1.19'
+          - '1.18'
           - '1.17'
           - '1.16'
           - '1.15'

--- a/colorable_appengine.go
+++ b/colorable_appengine.go
@@ -11,9 +11,9 @@ import (
 )
 
 // NewColorable returns new instance of Writer which handles escape sequence.
-func NewColorable(file *os.File) io.Writer {
+func NewColorable(file io.Writer) io.Writer {
 	if file == nil {
-		panic("nil passed instead of *os.File to NewColorable()")
+		panic("nil passed instead of io.Writer to NewColorable()")
 	}
 
 	return file

--- a/colorable_others.go
+++ b/colorable_others.go
@@ -11,9 +11,9 @@ import (
 )
 
 // NewColorable returns new instance of Writer which handles escape sequence.
-func NewColorable(file *os.File) io.Writer {
+func NewColorable(file io.Writer) io.Writer {
 	if file == nil {
-		panic("nil passed instead of *os.File to NewColorable()")
+		panic("nil passed instead of io.Writer to NewColorable()")
 	}
 
 	return file

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,6 @@ module github.com/mattn/go-colorable
 require github.com/mattn/go-isatty v0.0.16
 
 go 1.15
+
+// FIXME: remove, after merge of https://github.com/mattn/go-isatty/pull/81
+replace github.com/mattn/go-isatty => github.com/cardil/mattn-isatty v0.0.0-20230228121058-48002435730c

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/cardil/mattn-isatty v0.0.0-20230228121058-48002435730c h1:vitLC/i2BOWniuLac5nzO8B4idybJbTDejvh2N0n4nE=
+github.com/cardil/mattn-isatty v0.0.0-20230228121058-48002435730c/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Fixes #65 
Require https://github.com/mattn/go-isatty/pull/81