### PR TITLE
Windows: do not export Writer

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -87,8 +87,8 @@ var (
 	procCreateConsoleScreenBuffer  = kernel32.NewProc("CreateConsoleScreenBuffer")
 )
 
-// Writer provides colorable Writer to the console
-type Writer struct {
+// writer provides colorable Writer to the console
+type writer struct {
 	out       io.Writer
 	handle    syscall.Handle
 	althandle syscall.Handle
@@ -98,7 +98,7 @@ type Writer struct {
 	mutex     sync.Mutex
 }
 
-// NewColorable returns new instance of Writer which handles escape sequence from File.
+// NewColorable returns new instance of writer which handles escape sequence from File.
 func NewColorable(file *os.File) io.Writer {
 	if file == nil {
 		panic("nil passed instead of *os.File to NewColorable()")
@@ -112,17 +112,17 @@ func NewColorable(file *os.File) io.Writer {
 		var csbi consoleScreenBufferInfo
 		handle := syscall.Handle(file.Fd())
 		procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
-		return &Writer{out: file, handle: handle, oldattr: csbi.attributes, oldpos: coord{0, 0}}
+		return &writer{out: file, handle: handle, oldattr: csbi.attributes, oldpos: coord{0, 0}}
 	}
 	return file
 }
 
-// NewColorableStdout returns new instance of Writer which handles escape sequence for stdout.
+// NewColorableStdout returns new instance of writer which handles escape sequence for stdout.
 func NewColorableStdout() io.Writer {
 	return NewColorable(os.Stdout)
 }
 
-// NewColorableStderr returns new instance of Writer which handles escape sequence for stderr.
+// NewColorableStderr returns new instance of writer which handles escape sequence for stderr.
 func NewColorableStderr() io.Writer {
 	return NewColorable(os.Stderr)
 }
@@ -434,7 +434,7 @@ func atoiWithDefault(s string, def int) (int, error) {
 }
 
 // Write writes data on console
-func (w *Writer) Write(data []byte) (n int, err error) {
+func (w *writer) Write(data []byte) (n int, err error) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 	var csbi consoleScreenBufferInfo


### PR DESCRIPTION
Do not expose symbol [`Writer`](https://pkg.go.dev/github.com/mattn/go-colorable?GOOS=windows#Writer). That symbol is purely internal and was only exported on `GOOS=windows` by mistake.

Currently:
```console
$ GOOS=linux go doc .
package colorable // import "github.com/mattn/go-colorable"

func EnableColorsStdout(enabled *bool) func()
func NewColorable(file *os.File) io.Writer
func NewColorableStderr() io.Writer
func NewColorableStdout() io.Writer
func NewNonColorable(w io.Writer) io.Writer
type NonColorable struct{ ... }
$ GOOS=windows go doc .
package colorable // import "github.com/mattn/go-colorable"

func EnableColorsStdout(enabled *bool) func()
func NewColorable(file *os.File) io.Writer
func NewColorableStderr() io.Writer
func NewColorableStdout() io.Writer
func NewNonColorable(w io.Writer) io.Writer
type NonColorable struct{ ... }
type Writer struct{ ... }
```