### PR TITLE
Use golang.org/x/term for the IsTerminal() API

### DIFF
--- a/colorable_others.go
+++ b/colorable_others.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	_ "github.com/mattn/go-isatty"
+	_ "golang.org/x/term"
 )
 
 // NewColorable returns new instance of Writer which handles escape sequence.

--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/mattn/go-isatty"
+	"golang.org/x/term"
 )
 
 const (
@@ -104,7 +104,7 @@ func NewColorable(file *os.File) io.Writer {
 		panic("nil passed instead of *os.File to NewColorable()")
 	}
 
-	if isatty.IsTerminal(file.Fd()) {
+	if term.IsTerminal(int(file.Fd())) {
 		var mode uint32
 		if r, _, _ := procGetConsoleMode.Call(file.Fd(), uintptr(unsafe.Pointer(&mode))); r != 0 && mode&cENABLE_VIRTUAL_TERMINAL_PROCESSING != 0 {
 			return file

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/mattn/go-colorable
 
-require github.com/mattn/go-isatty v0.0.16
+require (
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/term v0.1.0
+)
 
 go 1.15

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=


### PR DESCRIPTION
Packages from the golang.org domain are likely to be more widely used than github.com/mattn/go-isatty.  Therefore, this can reduce the number of dependencies for consumers of github.com/mattn/go-colorable, who may already have golang.org/x/term in their dependency chain.

Newer versions of golang.org/x/term require Go versions more recent than 1.15 [1].  Therefore, the minimum needed version was carefully chosen to avoid bumping the Go version.

[1] golang.org/x/term commit a79de5458b56c188
    https://github.com/golang/term/commit/a79de5458b56c188
    https://github.com/golang/go/issues/36460