### PR TITLE
Fix: ESC[E and ESC[F with no arguments did not move the cursor on the legacy terminal of Microsoft Windows

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -560,7 +560,7 @@ loop:
 			}
 			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'E':
-			n, err = strconv.Atoi(buf.String())
+			n, err = atoiWithDefault(buf.String(), 1)
 			if err != nil {
 				continue
 			}
@@ -569,7 +569,7 @@ loop:
 			csbi.cursorPosition.y += short(n)
 			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
 		case 'F':
-			n, err = strconv.Atoi(buf.String())
+			n, err = atoiWithDefault(buf.String(), 1)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
- The default value when arguments are omit was not set as 1.





#### ESC_F.go

```ESC_F.go
//go:build run

package main

import (
	"fmt"

	"github.com/mattn/go-colorable"
)

func main() {
	o := colorable.NewColorableStdout()

	fmt.Fprint(o, "First line\n")
	fmt.Fprint(o, "\x1B[FSecond line\n")
}
```

#### ESC_E.go

```ESC_E.go
//go:build run

package main

import (
	"fmt"

	"github.com/mattn/go-colorable"
)

func main() {
	o := colorable.NewColorableStdout()

	fmt.Fprint(o, "First line\n")
	fmt.Fprint(o, "\x1B[ESecond line\n")
}
```
