### PR TITLE
[Windows] harden system DLL loading

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
+	syscall "golang.org/x/sys/windows"
 	"unsafe"
 
 	"github.com/mattn/go-isatty"
@@ -73,7 +73,7 @@ type consoleCursorInfo struct {
 }
 
 var (
-	kernel32                       = syscall.NewLazyDLL("kernel32.dll")
+	kernel32                       = syscall.NewLazySystemDLL("kernel32.dll")
 	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
 	procSetConsoleTextAttribute    = kernel32.NewProc("SetConsoleTextAttribute")
 	procSetConsoleCursorPosition   = kernel32.NewProc("SetConsoleCursorPosition")

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/mattn/go-colorable
 
-require github.com/mattn/go-isatty v0.0.16
+require (
+	github.com/mattn/go-isatty v0.0.16
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab
+)
 
 go 1.15


### PR DESCRIPTION
Technically loading system DLLs from relative paths with NewLazyDLL is vulnerable to DLL preloading attacks. See the warning on NewLazyDLL here [0].

[0] https://pkg.go.dev/golang.org/x/sys/windows?GOOS=windows#NewLazyDLL

We had this filed as a bug against us in [Gio](https://gioui.org), and it prompted me to look through my dependency trees to try to help other people catch it.