### PR TITLE
Update Go reference badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/mattn/go-colorable/workflows/test/badge.svg)](https://github.com/mattn/go-colorable/actions?query=workflow%3Atest)
 [![Codecov](https://codecov.io/gh/mattn/go-colorable/branch/master/graph/badge.svg)](https://codecov.io/gh/mattn/go-colorable)
-[![GoDoc](https://godoc.org/github.com/mattn/go-colorable?status.svg)](http://godoc.org/github.com/mattn/go-colorable)
+[![Go Reference](https://pkg.go.dev/badge/github.com/mattn/go-colorable.svg)](https://pkg.go.dev/github.com/mattn/go-colorable)
 [![Go Report Card](https://goreportcard.com/badge/mattn/go-colorable)](https://goreportcard.com/report/mattn/go-colorable)
 
 Colorable writer for windows.


### PR DESCRIPTION
Generate badge reference using https://pkg.go.dev/badge

GoDoc is deprecated long time ago. See golang/go#49212 for details.