### PR TITLE
fix: handle nil File/stdout/stderr gracefully instead of panic

### DIFF
--- a/colorable_windows.go
+++ b/colorable_windows.go
@@ -101,7 +101,7 @@ type writer struct {
 // NewColorable returns new instance of writer which handles escape sequence from File.
 func NewColorable(file *os.File) io.Writer {
 	if file == nil {
-		panic("nil passed instead of *os.File to NewColorable()")
+		return NewNonColorable(io.Discard)
 	}
 
 	if isatty.IsTerminal(file.Fd()) {
@@ -119,11 +119,17 @@ func NewColorable(file *os.File) io.Writer {
 
 // NewColorableStdout returns new instance of writer which handles escape sequence for stdout.
 func NewColorableStdout() io.Writer {
+	if os.Stdout == nil {
+		return NewNonColorable(io.Discard)
+	}
 	return NewColorable(os.Stdout)
 }
 
 // NewColorableStderr returns new instance of writer which handles escape sequence for stderr.
 func NewColorableStderr() io.Writer {
+	if os.Stderr == nil {
+		return NewNonColorable(io.Discard)
+	}
 	return NewColorable(os.Stderr)
 }
 


### PR DESCRIPTION
## Problem

NewColorable() panics when passed a nil *os.File:



This happens when running as a Windows NT Service, where  is nil. The Windows service code path in  calls  during init, which propagates the panic to the entire program.

## Solution

Instead of panicking, return a NonColorable writer backed by :

- **NewColorable(file)**: When ==:  cannot open `==' (No such file or directory)
nil: cannot open `nil' (No such file or directory), return  instead of panic
- **NewColorableStdout()**: When , return  
- **NewColorableStderr()**: When , return 

This matches the workaround suggested by @mattn in the issue thread.

## Changes

- : Added nil guards to all three public constructors
- No behavior change for non-nil cases

## Testing

Go vet passes, build succeeds.

Fixes mattn/go-colorable#76